### PR TITLE
 🧹 CLEAN: remove extra \ufeff chars

### DIFF
--- a/detect_errors.py
+++ b/detect_errors.py
@@ -3,7 +3,7 @@ def search_lines_for_errors(filename):
   errors = 0
   with open(filename, 'r') as f:
     for i, line in enumerate(f.readlines()):
-      if '\ufeff' in line:
+      if "�" in line:
         print(f'Error in line {i+1}')
         errors += 1
   if errors == 0:

--- a/detect_errors.py
+++ b/detect_errors.py
@@ -1,0 +1,17 @@
+def search_lines_for_errors(filename):
+  print(f'Looking for errors in {filename}')
+  errors = 0
+  with open(filename, 'r') as f:
+    for i, line in enumerate(f.readlines()):
+      if '\ufeff' in line:
+        print(f'Error in line {i+1}')
+        errors += 1
+  if errors == 0:
+    print('No errors found!')
+  else:
+    print(f'{errors} errors were found')
+
+for partition in ['dev', 'test', 'train']:
+  filename = f'es_gsd-ud-{partition}.conllu'
+  search_lines_for_errors(filename)
+  print('='*20)

--- a/es_gsd-ud-dev.conllu
+++ b/es_gsd-ud-dev.conllu
@@ -37211,11 +37211,11 @@
 40	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = es-dev-003-s257
-# text = Asimismo, nuestro pa��s se sitúa en cuarto lugar en las preferencias de los turistas del país asiático, por detrás de Francia, Reino Unido y Alemania.
+# text = Asimismo, nuestro país se sitúa en cuarto lugar en las preferencias de los turistas del país asiático, por detrás de Francia, Reino Unido y Alemania.
 1	Asimismo	asimismo	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	,	,	PUNCT	_	_	1	punct	_	_
 3	nuestro	nuestro	DET	_	Gender=Masc|Number=Plur|Person=1|Poss=Yes|PronType=Prs	4	det	_	_
-4	pa��s	pa��s	NOUN	_	Gender=Masc|Number=Sing	6	nsubj	_	_
+4	país	país	NOUN	_	Gender=Masc|Number=Sing	6	nsubj	_	_
 5	se	él	PRON	_	Case=Acc,Dat|Person=3|PrepCase=Npr|PronType=Prs|Reflex=Yes	6	iobj	_	_
 6	sitúa	situar	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 7	en	en	ADP	_	_	9	case	_	_


### PR DESCRIPTION
# 🧹 CLEAN: remove extra `\ufeff` chars
7 sentences have an undeleted `\ufeff` char. When tokenizing these sentences, this extra char could force an [UNK] token if not cleaned correctly.

You can't see the difference in the GitHub preview. I also added a small [python script](https://github.com/Aiquinones/UD_Spanish-GSD/blob/clean-train/detect_errors.py) that checks for this char so the problem can be verified.

Running the script, one gets:
<pre><code>Looking for errors in es_gsd-ud-dev.conllu
No errors found!
====================
Looking for errors in es_gsd-ud-test.conllu
No errors found!
====================
Looking for errors in es_gsd-ud-train.conllu
Error in line 10632
Error in line 10633
Error in line 39679
Error in line 39680
Error in line 171991
Error in line 171992
Error in line 172132
Error in line 172133
Error in line 206759
Error in line 206760
Error in line 257221
Error in line 257222
Error in line 282580
Error in line 282581
14 errors were found
====================
</code></pre>