### PR TITLE
más que edits for comparatives:

### DIFF
--- a/es_gsd-ud-dev.conllu
+++ b/es_gsd-ud-dev.conllu
@@ -932,8 +932,8 @@
 # sent_id = es-dev-001-s39
 # text = Estoy más que tranquila cuando dejo a Bruc allí pues veo a Eli y Rosa que adoran los animales y el cariño con que lo tratan.
 1	Estoy	estar	AUX	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	_	_
-2	más	más	ADV	_	Degree=Cmp	4	advmod	_	_
-3	que	que	CCONJ	_	_	2	case	_	_
+2	más	más	ADV	_	Degree=Cmp|ExtPos=ADV	4	advmod	_	_
+3	que	que	SCONJ	_	_	2	fixed	_	_
 4	tranquila	tranquilo	ADJ	_	Gender=Fem|Number=Sing	0	root	_	_
 5	cuando	cuando	SCONJ	_	_	6	mark	_	_
 6	dejo	dejar	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	advcl	_	_
@@ -14547,14 +14547,14 @@
 13	y	y	CCONJ	_	_	15	cc	_	_
 14	hasta	hasta	ADP	_	_	15	case	_	_
 15	Inglaterra	Inglaterra	PROPN	_	_	6	conj	_	SpaceAfter=No
-16	,	,	PUNCT	_	PunctType=Comm	18	punct	_	_
-17	pero	pero	CCONJ	_	_	18	cc	_	_
-18	es	ser	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	conj	_	_
-19	más	más	ADV	_	Degree=Cmp	18	advmod	_	_
-20	que	que	CCONJ	_	_	21	case	_	_
-21	dudoso	dudoso	ADV	_	_	19	advmod	_	_
+16	,	,	PUNCT	_	PunctType=Comm	21	punct	_	_
+17	pero	pero	CCONJ	_	_	21	cc	_	_
+18	es	ser	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	cop	_	_
+19	más	más	ADV	_	Degree=Cmp|ExtPos=ADV	21	advmod	_	_
+20	que	que	SCONJ	_	_	19	fixed	_	_
+21	dudoso	dudoso	ADJ	_	_	1	conj	_	_
 22	que	que	SCONJ	_	_	23	mark	_	_
-23	cruzaran	cruzar	VERB	_	Mood=Sub|Number=Plur|Person=3|Tense=Imp|VerbForm=Fin	18	csubj	_	_
+23	cruzaran	cruzar	VERB	_	Mood=Sub|Number=Plur|Person=3|Tense=Imp|VerbForm=Fin	21	csubj	_	_
 24	el	el	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
 25	Océano	Océano	PROPN	_	Gender=Masc|Number=Sing	23	obj	_	_
 26	Atlántico	Atlántico	PROPN	_	_	25	amod	_	_

--- a/es_gsd-ud-dev.conllu
+++ b/es_gsd-ud-dev.conllu
@@ -12778,9 +12778,9 @@
 7	necesariamente	necesariamente	ADV	_	_	9	advmod	_	_
 8	más	más	ADV	_	Degree=Cmp	9	advmod	_	_
 9	propensos	propenso	ADJ	_	Gender=Masc|Number=Plur	0	root	_	_
-10	que	que	CCONJ	_	_	12	case	_	_
+10	que	que	SCONJ	_	_	12	case	_	_
 11	otros	otro	DET	_	Gender=Masc|Number=Plur|PronType=Ind	12	det	_	_
-12	estadounidenses	estadounidense	NOUN	_	Number=Plur	8	nmod	_	_
+12	estadounidenses	estadounidense	NOUN	_	Number=Plur	9	obl	_	_
 13	a	a	ADP	_	_	14	mark	_	_
 14	consumir	consumir	VERB	_	VerbForm=Inf	9	advcl	_	_
 15	marihuana	marihuano	NOUN	_	Gender=Fem|Number=Sing	14	obj	_	SpaceAfter=No
@@ -14299,8 +14299,8 @@
 5	tener	tener	VERB	_	VerbForm=Inf	0	root	_	_
 6	más	más	ADV	_	Degree=Cmp	7	advmod	_	_
 7	inmunidad	inmunidad	NOUN	_	Gender=Fem|Number=Sing	5	obj	_	_
-8	que	que	CCONJ	_	_	9	case	_	_
-9	la	él	PRON	_	Case=Acc|Gender=Fem|Number=Sing|Person=3|PrepCase=Npr|PronType=Prs	6	nmod	_	_
+8	que	que	SCONJ	_	_	9	case	_	_
+9	la	él	PRON	_	Case=Acc|Gender=Fem|Number=Sing|Person=3|PrepCase=Npr|PronType=Prs	7	nmod	_	_
 10	que	que	SCONJ	_	_	12	mark	_	_
 11	le	él	PRON	_	Case=Dat|Number=Sing|Person=3|PronType=Prs	12	obl:arg	_	_
 12	concede	conceder	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	_	_
@@ -16586,9 +16586,9 @@
 23	parece	parecer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	advcl	_	_
 24	poco	poco	PRON	_	NumType=Card|PronType=Ind	25	nmod	_	_
 25	más	más	ADV	_	Degree=Cmp	23	advmod	_	_
-26	que	que	CCONJ	_	_	28	case	_	_
+26	que	que	SCONJ	_	_	28	case	_	_
 27	un	uno	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	28	det	_	_
-28	utilitario	utilitario	NOUN	_	Gender=Masc|Number=Sing	25	nmod	_	_
+28	utilitario	utilitario	NOUN	_	Gender=Masc|Number=Sing	25	obl	_	_
 29	berlina	berlina	NOUN	_	Number=Sing	28	appos	_	_
 30	con	con	ADP	_	_	31	case	_	_
 31	esteroides	esteroid	NOUN	_	Gender=Fem|Number=Plur	28	nmod	_	SpaceAfter=No
@@ -25803,11 +25803,11 @@
 22	a	a	ADP	_	_	24	case	_	_
 23	el	el	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
 24	nynorsk	nynorsk	NOUN	_	_	20	obl:arg	_	_
-25	que	que	CCONJ	_	_	21	dep	_	_
+25	que	que	SCONJ	_	_	28	case	_	_
 26-27	al	_	_	_	_	_	_	_	_
 26	a	a	ADP	_	_	28	case	_	_
 27	el	el	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	28	det	_	_
-28	bokmål	bokmål	NOUN	_	Gender=Masc|Number=Sing	25	nmod	_	SpaceAfter=No
+28	bokmål	bokmål	NOUN	_	Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
 29	.	.	PUNCT	_	PunctType=Peri	8	punct	_	_
 
 # sent_id = es-dev-002-s366
@@ -29193,9 +29193,9 @@
 11	en	en	ADP	_	_	13	case	_	_
 12	lo	él	PRON	_	Case=Acc|Gender=Masc|Number=Sing|Person=3|PrepCase=Npr|PronType=Prs	13	det	_	_
 13	digital	digital	NOUN	_	Number=Sing	8	obl	_	_
-14	que	que	CCONJ	_	_	9	dep	_	_
+14	que	que	SCONJ	_	_	16	case	_	_
 15	en	en	ADP	_	_	16	case	_	_
-16	radios	radio	NOUN	_	Gender=Fem|Number=Plur	14	nmod	_	SpaceAfter=No
+16	radios	radio	NOUN	_	Gender=Fem|Number=Plur	9	obl	_	SpaceAfter=No
 17	,	,	PUNCT	_	PunctType=Comm	18	punct	_	_
 18	tele	tele	NOUN	_	Gender=Fem|Number=Sing	16	conj	_	_
 19	o	o	CCONJ	_	_	20	cc	_	_
@@ -35357,9 +35357,9 @@
 7	semidesintegración	semidesintegración	NOUN	_	Gender=Fem|Number=Sing	5	nmod	_	_
 8	más	más	ADV	_	Degree=Cmp	9	advmod	_	_
 9	cortos	corto	ADJ	_	Gender=Masc|Number=Plur	5	amod	_	_
-10	que	que	CCONJ	_	_	12	case	_	_
+10	que	que	SCONJ	_	_	12	case	_	_
 11	una	uno	DET	_	Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	hora	hora	NOUN	_	Gender=Fem|Number=Sing	9	nmod	_	SpaceAfter=No
+12	hora	hora	NOUN	_	Gender=Fem|Number=Sing	9	obl	_	SpaceAfter=No
 13	,	,	PUNCT	_	PunctType=Comm	16	punct	_	_
 14	y	y	CCONJ	_	_	16	cc	_	_
 15	la	el	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
@@ -39548,10 +39548,10 @@
 8	el	el	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
 9	primer	primero	ADJ	_	Gender=Masc|Number=Sing|NumType=Ord	10	amod	_	_
 10	equipo	equipo	NOUN	_	Gender=Masc|Number=Sing	5	nmod	_	_
-11	que	que	CCONJ	_	_	6	dep	_	_
+11	que	que	SCONJ	_	_	14	case	_	_
 12	durante	durante	ADP	_	_	14	case	_	_
 13	la	el	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
-14	temporada	temporada	NOUN	_	Gender=Fem|Number=Sing	11	nmod	_	_
+14	temporada	temporada	NOUN	_	Gender=Fem|Number=Sing	5	obl	_	_
 15	anterior	anterior	ADJ	_	Number=Sing	14	amod	_	SpaceAfter=No
 16	.	.	PUNCT	_	PunctType=Peri	1	punct	_	_
 

--- a/es_gsd-ud-test.conllu
+++ b/es_gsd-ud-test.conllu
@@ -4839,7 +4839,7 @@
 5	de	de	ADP	_	_	6	mark	_	_
 6	compartir	compartir	VERB	_	VerbForm=Inf	3	advcl	_	_
 7	música	música	NOUN	_	Gender=Fem|Number=Sing	6	obj	_	_
-8	que	que	CCONJ	_	_	10	mark	_	_
+8	que	que	SCONJ	_	_	10	mark	_	_
 9	de	de	ADP	_	_	10	mark	_	_
 10-11	piratearla	_	_	_	_	_	_	_	SpaceAfter=No
 10	piratear	piratear	VERB	_	VerbForm=Inf	4	advcl	_	_
@@ -7710,7 +7710,7 @@
 43	sin	sin	ADP	_	_	45	case	_	_
 44	más	más	ADV	_	Degree=Cmp	45	advmod	_	_
 45	premisa	premisa	NOUN	_	Gender=Fem|Number=Sing	41	conj	_	_
-46	que	que	CCONJ	_	_	47	mark	_	_
+46	que	que	SCONJ	_	_	47	mark	_	_
 47	meter	meter	VERB	_	VerbForm=Inf	44	advcl	_	_
 48	a	a	ADP	_	_	49	case	_	_
 49	todos	todo	PRON	_	Gender=Masc|Number=Plur|PronType=Tot	47	obj	_	_
@@ -8941,9 +8941,9 @@
 26	hasta	hasta	ADV	_	_	27	advmod	_	_
 27	dos	dos	NUM	_	Number=Plur|NumForm=Word|NumType=Card	23	conj	_	_
 28	más	más	ADV	_	Degree=Cmp	23	advmod	_	_
-29	que	que	CCONJ	_	_	31	case	_	_
+29	que	que	SCONJ	_	_	31	case	_	_
 30	sus	su	DET	_	Number=Plur|Person=3|Poss=Yes|PronType=Prs	31	det	_	_
-31	rivales	rival	NOUN	_	Number=Plur	28	nmod	_	_
+31	rivales	rival	NOUN	_	Number=Plur	23	obl	_	_
 32	no	no	ADV	_	Polarity=Neg	33	advmod	_	_
 33	ocupa	ocupar	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	advcl	_	_
 34	ningún	ninguno	DET	_	Gender=Masc|Number=Sing|PronType=Neg	35	det	_	_
@@ -12464,8 +12464,8 @@
 14	es	ser	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	cop	_	_
 15	más	más	ADV	_	Degree=Cmp	16	advmod	_	_
 16	bonito	bonito	ADJ	_	Gender=Masc|Number=Sing	6	conj	_	_
-17	que	que	CCONJ	_	_	18	case	_	_
-18	el	el	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	15	nmod	_	_
+17	que	que	SCONJ	_	_	18	case	_	_
+18	el	el	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	16	obl	_	_
 19	de	de	ADP	_	_	20	case	_	_
 20	Scotex	Scotex	PROPN	_	_	18	nmod	_	SpaceAfter=No
 21	!	!	PUNCT	_	PunctSide=Fin|PunctType=Excl	6	punct	_	_


### PR DESCRIPTION
más que edits for comparatives:

que CCONJ to SCONJ
standard re-headed onto the graded word except when más grades a verb obl under ADJ/ADV/más, nmod under NOUN/PROPN/PRON
8 dep restructures

https://universaldependencies.org/u/overview/comparatives.html

attempting to follow this general guideline:

3  más          mucho       ADV    Degree=Cmp   4  advmod
4  inteligente  inteligente ADJ                 0  root
5  que          que         SCONJ               6  case
6  Martín       Martín      PROPN               4  obl

and the explanation given here:

https://github.com/UniversalDependencies/docs/issues/1293#issuecomment-5302338772